### PR TITLE
Add dirmngr to plain Raspbian install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ We love Open Source & Qt. Contribute here.
 
 Add the nymea repository to your system:
 
+    sudo apt install dirmngr
     echo "deb http://repository.nymea.io stretch main raspbian" | sudo tee /etc/apt/sources.list.d/nymea.list
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key A1A19ED6
 


### PR DESCRIPTION
A fresh install of raspbian (tested on 2019-04-08 release) requires
dirmngr package to avoid an error in the apt-key step